### PR TITLE
Google AdSenseを追加

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -2,6 +2,21 @@ module.exports = {
 	title: "東雲火山の山麓",
 	description: "株式会社東雲火山関連の記事等置き場",
 	theme: '@vuepress/default',
+	head: [
+		[
+			"script",
+			{src: "//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js",
+			async: true}
+		],
+		[
+			"script",
+			{},
+			`(adsbygoogle = window.adsbygoogle || []).push({
+google_ad_client: "ca-pub-5067037356613716",
+enable_page_level_ads: true
+});`,
+		]
+	],
 	themeConfig: {
 		nav: [
 			{ text: "リンク集", items: [


### PR DESCRIPTION
## このPRが解決する内容

Google AdSenseを追加します。

このrepositoryはあまり再利用性を考えていないので、IDそのまま埋め込んじゃいます。

## 解説

- Vue.jsを使う方法が解説されたりもしているようです
    - https://v-meta.com/blog/google-adsense.html
- 多分将来的にはVuePressにプラグインが生えると思います
- このPRでは、とりあえずシンプルにheadにスクリプト埋め込むだけにしてみました
    - 挙動見て後で変える、かもしれません


